### PR TITLE
Reprint invoices

### DIFF
--- a/src/ClientScripts/reprint_invoices_client.ts
+++ b/src/ClientScripts/reprint_invoices_client.ts
@@ -5,6 +5,7 @@
 
 import { EntryPoints } from 'N/types';
 import * as currentRecord from 'N/currentRecord';
+import * as dialog from 'N/ui/dialog';
 
 export let pageInit: EntryPoints.Client.pageInit = () => {
   console.log('Re-Print Invoice(s) Client Loaded...');
@@ -22,6 +23,7 @@ export let saveRecord: EntryPoints.Client.saveRecord = () => {
   const cr = currentRecord.get();
   const lines = cr.getLineCount({ sublistId: 'custpage_transactions_sublist' });
   let transactions = [];
+  let transactionStr = '';
   for (let i = 0; i < lines; i++) {
     const cb = cr.getSublistValue({
       sublistId: 'custpage_transactions_sublist',
@@ -43,8 +45,15 @@ export let saveRecord: EntryPoints.Client.saveRecord = () => {
         transactionId: transactionId,
         transactionNumber: transactionNumber,
       });
+      transactionStr += `, ${transactionNumber}`;
     }
   }
+
+  dialog.alert({
+    title: 'Processing PDF(s)',
+    message: `Please do not reload page. The following Invoices will be merged: ${transactionStr}. 
+    The generated PDF will be automatically downloaded once it is finished processing.`,
+  });
   console.log('Setting custpage_transactions: ' + JSON.stringify(transactions));
   cr.setValue('custpage_transactions', JSON.stringify(transactions));
   return true;

--- a/src/Suitelets/reprint_invoices.ts
+++ b/src/Suitelets/reprint_invoices.ts
@@ -129,7 +129,7 @@ const getInvoices = (
 const onGet = (response: ServerResponse) => {
   const form = serverWidget.createForm({ title: 'Print Invoices' });
   form.addSubmitButton({
-    label: 'Submit',
+    label: 'Search',
   });
 
   form
@@ -143,13 +143,18 @@ const onGet = (response: ServerResponse) => {
     })
     .updateBreakType({
       breakType: serverWidget.FieldBreakType.STARTROW,
-    }).defaultValue = 'Search for invoices by customer internal id.';
+    }).defaultValue = `Search for and merge invoices by customer internal id.<br/>You can get the customers internal 
+    id by looking at the customer record.<br/>The internal id will be in the customer record url.
+    It will look something<br/>like this <b>id=1234567</b>. You will only need the numbers. If the customer
+    has subcustomers<br/>and you want to merge the invoices of all subcustomers check <b>master customer</b>.`;
 
-  form.addField({
+  const customerInternalId = form.addField({
     id: 'custpage_customer_internal_id',
     label: 'Customers Internal ID',
     type: serverWidget.FieldType.TEXT,
   });
+
+  customerInternalId.isMandatory = true;
 
   form.addField({
     id: 'custpage_customer_is_parent',
@@ -222,7 +227,7 @@ const onPost = (request: ServerRequest, response: ServerResponse) => {
 
       response.writeFile({
         file: pdfFile,
-        isInline: true,
+        isInline: false,
       });
     }
   }
@@ -244,7 +249,7 @@ const createPage = (
   if (results) {
     form.clientScriptModulePath = 'SuiteScripts/reprint_invoices_client.js';
     form.addSubmitButton({
-      label: 'Submit',
+      label: 'Generate PDF',
     });
 
     form

--- a/src/Suitelets/reprint_invoices.ts
+++ b/src/Suitelets/reprint_invoices.ts
@@ -80,6 +80,7 @@ const getInvoices = (
     filters.push(
       search.createFilter({
         name: 'internalid',
+        join: 'customer',
         operator: search.Operator.ANYOF,
         values: [customerId],
       })


### PR DESCRIPTION
# Changes
- Added Re-Print Invoices SuiteLet
  - This SuitLet will let the user search for customer invoices and merge multiple invoices into one PDF. The generated PDF will be downloaded automatically. The user will then be able to print the pdf or send it via email.
  - Updated SuiteLet with dialog letting the user know that the PDF is being generated.
  - Still need to add some sort of loader for better user feedback.